### PR TITLE
fix: use ecr for postgres image

### DIFF
--- a/cluster/apps/dbms/postgres/helm-release.yaml
+++ b/cluster/apps/dbms/postgres/helm-release.yaml
@@ -18,6 +18,7 @@ spec:
       interval: 5m
   values:
     image:
+      registry: public.ecr.aws
       repository: bitnami/postgresql
       tag: 14.1.0-debian-10-r80
     architecture: standalone


### PR DESCRIPTION
DockerHub has dumb pull limits and it's easy to get rate limted, With a little investigation and this command you can see what else you can migrate over to another repository

```
kubectl get pods --all-namespaces -o=jsonpath="{range .items[*]}{'\n'}{range .spec.containers[*]}{.image}{'\n'}{end}{end}" | sort | uniq | grep -Ev 'quay|gcr|ghcr|ecr' |  sed -e 's/docker\.io\///g' | sort | uniq
```